### PR TITLE
Append `?authuser=1` to hangout link.

### DIFF
--- a/src/hangouts.coffee
+++ b/src/hangouts.coffee
@@ -63,8 +63,7 @@ module.exports = (robot) ->
         msg.send "I'm sorry. Something went wrong and I wasn't able to create a hangout :("
       else
         response  = "I've started a hangout titled '#{summary}'"
-        response += ": #{event.hangoutLink}"
-        response += " (you may need to add ?authuser=1 if you're signed into multiple accounts)"
+        response += ": #{event.hangoutLink}?authuser=1"
         msg.send response
 
   createCalendarEvent = (msg, summary, description, callback) ->


### PR DESCRIPTION
Doesn't cause any adverse effects on users who don't need it and ensures a clickable link for those who do.

Just a personal irritation. Feel free to request another approach.

Thanks!
