### PR TITLE
Fix case-sensitive regex

### DIFF
--- a/src/hangouts.coffee
+++ b/src/hangouts.coffee
@@ -11,7 +11,7 @@
 hangoutsDomain = process.env.HUBOT_GOOGLE_HANGOUTS_DOMAIN
 
 module.exports = (robot) ->
-  robot.respond /hangouts?( me)?\s*"?(.*?)"?$/, (msg) ->
+  robot.respond /hangouts?( me)?\s*"?(.*?)"?$/i, (msg) ->
     return if missingEnvironment(msg)
 
     console.log msg.match


### PR DESCRIPTION
Currently, the regex is case sensitive, which means you have to issue commands to the bot with the correct case. Be default, the hubot username is "Hubot". This means the following work in most plugins, but not this one:

works:
`Hubot hangout test`
does not work:
`hubot hangout test`

For most other plugins, the regex is not case sensitive so these both work:

```
hubot help
Hubot help
```

This fixes this plugin so it works the same as the native ones.
